### PR TITLE
Add list option to Sale Offer Variants to obtain list of Variant sets

### DIFF
--- a/allegroapi/base.py
+++ b/allegroapi/base.py
@@ -22,11 +22,17 @@ class BaseApi(object):
         self._a_client = a_client
         self.endpoint = ''
 
-    def _build_path(self, *args):
+    def _build_path(self, *args, **kwargs):
         """
         Build path with endpoint and args
 
         :param args: Path elements in the endpoint URL
         :type args: :py:class:`unicode`
         """
-        return '/'.join(chain((self.endpoint,), map(str, args)))
+        path = '/'.join(chain((self.endpoint,), map(str, args)))
+        if kwargs:
+            params_path = "&".join(f"{key}={value}" for key, value in kwargs.items())
+            path = path + "?" + params_path
+            print(path)
+
+        return path

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     version='0.0.1',    
     description='Simple wrapper (client) for Allegro.pl REST API written in Python (using requests)',
     url='https://github.com/chawel/python-allegro.git',
-    license=license,
+    license="MIT",
     packages=find_packages(exclude=('tests', 'docs')),
 )


### PR DESCRIPTION
Add list option to Sale Offer Variants to obtain list of Variant sets and extend BaseApi _build_path to accept kwargs to add parameters to path.